### PR TITLE
⬆️  Updates brakeman, rubocop, flay and nokogiri gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ LineLength:
 ClassLength:
   Enabled: false
 
-Style/CommentIndentation:
+Layout/CommentIndentation:
   Enabled: false
 
 Style/ClassAndModuleChildren:
@@ -27,7 +27,7 @@ HashSyntax:
 Style/SignalException:
   Enabled: false
 
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
 Lint/AmbiguousOperator:
@@ -57,16 +57,16 @@ Style/StringLiteralsInInterpolation:
 Style/NumericLiterals:
   Enabled: false
 
-Style/FirstParameterIndentation:
+Layout/FirstParameterIndentation:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Enabled: false
 
 Metrics/ModuleLength:
@@ -90,13 +90,13 @@ Style/Documentation:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Enabled: false
 
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
 Style/SingleLineBlockParams:
@@ -161,7 +161,7 @@ Style/FormatString:
 Metrics/BlockNesting:
   Enabled: false
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Width: 2
 
 Lint/NonLocalExitFromIterator:

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,3 @@
 source "https://rubygems.org"
+
 gemspec
-
-# Add dependencies required to use your gem here.
-# Example:
-#   gem "activesupport", ">= 2.3.5"
-
-# Add dependencies to develop your gem here.
-# Include everything needed to run rake, tests, features, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       memory_profiler (~> 0.9)
     benchmark-perf (0.2.1)
     brakecheck (0.2.2)
-    brakeman (3.6.1)
+    brakeman (3.7.0)
     bump (0.5.3)
     bundler-audit (0.5.0)
       bundler (~> 1.2)
@@ -29,14 +29,16 @@ GEM
       sexp_processor (~> 4.0)
     htmlentities (4.3.4)
     memory_profiler (0.9.7)
-    mini_portile2 (2.1.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    mini_portile2 (2.2.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
+    parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
-    path_expander (1.0.1)
+    path_expander (1.0.2)
     powerpack (0.1.1)
-    rainbow (2.2.1)
+    rainbow (2.2.2)
+      rake
     rake (11.3.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -54,7 +56,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.48.1)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -65,7 +68,7 @@ GEM
       sexp_processor (~> 4.1)
     sexp_processor (4.9.0)
     thor (0.19.4)
-    unicode-display_width (1.1.3)
+    unicode-display_width (1.3.0)
     wwtd (1.3.0)
 
 PLATFORMS
@@ -88,4 +91,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.14.6
+   1.15.1


### PR DESCRIPTION
/cc @jwsf +1

### Description

Our monthly build is back to red since brakeman, rubocop, flay and nokogiri gems are not updated: 
https://travis-ci.org/zendesk/abbreviato

### Tasks

- [x] Update  brakeman, rubocop, flay and nokogiri gems
- [x] Update rubocop.yml to the new defaults (Style → Layout).
- [x] Fix CVE-2017-5029:

```ruby
START env: TASK='bundle:audit'
bundle install --quiet
bundle exec rake $TASK
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up-to-date.
Updated ruby-advisory-db
ruby-advisory-db: 287 advisories
Name: nokogiri
Version: 1.7.1
Advisory: CVE-2017-5029
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1634
Title: Nokogiri gem contains two upstream vulnerabilities in libxslt 1.1.29
Solution: upgrade to >= 1.7.2

Vulnerabilities found!
```

### Steps to reproduce

```ruby
bundle exec rake wwtd
```