### PR TITLE
Update brakeman and rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       memory_profiler (~> 0.9)
     benchmark-perf (0.2.1)
     brakecheck (0.2.2)
-    brakeman (4.0.1)
+    brakeman (4.1.1)
     bump (0.5.3)
     bundler-audit (0.6.0)
       bundler (~> 1.2)
@@ -32,13 +32,12 @@ GEM
     mini_portile2 (2.3.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    parallel (1.12.0)
-    parser (2.4.0.0)
-      ast (~> 2.2)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     path_expander (1.0.2)
     powerpack (0.1.1)
-    rainbow (2.2.2)
-      rake
+    rainbow (3.0.0)
     rake (11.3.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -56,11 +55,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.51.0)
+    rubocop (0.52.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
@@ -91,4 +90,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
cc @zendesk/sustaining @zendesk/strongbad 

### Description
I was gonna bump the version after merging [Nokogiri update PR](https://github.com/zendesk/abbreviato/pull/9) but the build was 🔴 

Brakeman https://travis-ci.org/zendesk/abbreviato/jobs/325327429

Rubocop https://travis-ci.org/zendesk/abbreviato/jobs/325328992

### Steps to reproduce
n/a

  