### PR TITLE
Bump v0.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abbreviato (0.8.0)
+    abbreviato (0.8.2)
       htmlentities (~> 4.3.4)
       nokogiri (>= 1.8.1)
 

--- a/lib/abbreviato/version.rb
+++ b/lib/abbreviato/version.rb
@@ -1,3 +1,3 @@
 module Abbreviato
-  VERSION = '0.8.0'.freeze
+  VERSION = '0.8.2'.freeze
 end


### PR DESCRIPTION
### Description
Bumping to a new version 
cc @zendesk/sustaining @maleko 

```
$> git push
Counting objects: 6, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (5/5), done.
Writing objects: 100% (6/6), 540 bytes | 540.00 KiB/s, done.
Total 6 (delta 3), reused 0 (delta 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: Required status check "continuous-integration/travis-ci" is expected.
To github.com:zendesk/abbreviato.git
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'git@github.com:zendesk/abbreviato.git'
```

### Steps to reproduce


### Note
v0.8.1 was already existing in https://rubygems.org/gems/abbreviato