### PR TITLE
Update gems to fix failing build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     abbreviato (0.8.4)
       htmlentities (~> 4.3.4)
-      nokogiri (>= 1.8.3)
+      nokogiri (>= 1.8.5)
 
 GEM
   remote: https://rubygems.org/
@@ -32,10 +32,10 @@ GEM
     jaro_winkler (1.5.1-x86_64-darwin-17)
     memory_profiler (0.9.7)
     mini_portile2 (2.3.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     path_expander (1.0.3)
     powerpack (0.1.2)
@@ -57,15 +57,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.58.2)
+    rubocop (0.60.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
     sexp_processor (4.11.0)
@@ -94,4 +94,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ if %w[development test].include?(ENV["RAILS_ENV"] ||= 'development')
     result = `#{command}`
     result.force_encoding('binary')
     raise "Command #{command} failed: #{result}" unless $?.success?
+
     result
   end
 

--- a/abbreviato.gemspec
+++ b/abbreviato.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.summary = "A tool for efficiently truncating HTML strings to a specific bytesize"
 
   s.add_dependency "htmlentities", "~> 4.3.4"
-  s.add_dependency "nokogiri", ">= 1.8.3"
+  s.add_dependency "nokogiri", ">= 1.8.5"
 
   s.add_development_dependency "awesome_print"
   s.add_development_dependency "benchmark-memory"


### PR DESCRIPTION
### Description
Current build is failing due to the ff:

- Local version 0.58.2 of rubocop is not the latest version 0.60.0
- Nokogiri gem, via libxml2, is affected by multiple vulnerabilities

cc @zendesk/strongbad @zendesk/sustaining 