### PR TITLE
Update rubocop to v0.61.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abbreviato (0.8.4)
+    abbreviato (0.8.5)
       htmlentities (~> 4.3.4)
       nokogiri (>= 1.8.5)
 
@@ -57,7 +57,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.60.0)
+    rubocop (0.61.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)

--- a/lib/abbreviato/version.rb
+++ b/lib/abbreviato/version.rb
@@ -1,3 +1,3 @@
 module Abbreviato
-  VERSION = '0.8.4'.freeze
+  VERSION = '0.8.5'.freeze
 end


### PR DESCRIPTION
### Description
Update rubocop to since build is failing
https://travis-ci.org/zendesk/abbreviato/builds/464084709?utm_source=github_status&utm_medium=notification
```
+[false, "Local version 0.60.0 of rubocop is not the latest version 0.61.0"]
```

cc @zendesk/strongbad 
