### PR TITLE
Update rubocop to v0.61.0 to fix failing build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.60.0)
+    rubocop (0.61.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)


### PR DESCRIPTION
### Description
Update rubocop to since build is failing
https://travis-ci.org/zendesk/abbreviato/builds/464084709?utm_source=github_status&utm_medium=notification
```
+[false, "Local version 0.60.0 of rubocop is not the latest version 0.61.0"]
```

cc @zendesk/strongbad 

