### PR TITLE
Fix failing build 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,7 @@ GEM
       ruby_parser (~> 3.0)
       sexp_processor (~> 4.0)
     htmlentities (4.3.4)
-    jaro_winkler (1.5.1)
-    jaro_winkler (1.5.1-x86_64-darwin-17)
+    jaro_winkler (1.5.2)
     memory_profiler (0.9.7)
     mini_portile2 (2.3.0)
     nokogiri (1.8.5)
@@ -57,7 +56,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.61.0)
+    rubocop (0.62.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -70,7 +69,7 @@ GEM
       sexp_processor (~> 4.9)
     sexp_processor (4.11.0)
     thor (0.20.0)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     wwtd (1.3.0)
 
 PLATFORMS


### PR DESCRIPTION
### Description
Update rubocop to v0.62.0

```
"Local version 0.61.0 of rubocop is not the latest version 0.62.0"
```
