### PR TITLE
Update rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.63.1)
+    rubocop (0.64.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)


### PR DESCRIPTION
### Description
Failing build due to

```
"Local version 0.63.1 of rubocop is not the latest version 0.64.0"
```
 
cc @zendesk/sustaining 