### PR TITLE
Bump to v0.8.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abbreviato (0.8.6)
+    abbreviato (0.8.7)
       htmlentities (~> 4.3.4)
       nokogiri (>= 1.8.5)
 
@@ -39,6 +39,7 @@ GEM
       ast (~> 2.4.0)
     path_expander (1.0.3)
     powerpack (0.1.2)
+    psych (3.1.0)
     rainbow (3.0.0)
     rake (11.3.0)
     rspec (3.5.0)
@@ -58,11 +59,12 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.64.0)
+    rubocop (0.65.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
+      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)

--- a/lib/abbreviato/version.rb
+++ b/lib/abbreviato/version.rb
@@ -1,3 +1,3 @@
 module Abbreviato
-  VERSION = '0.8.6'.freeze
+  VERSION = '0.8.7'.freeze
 end


### PR DESCRIPTION
### Description
Bump version to release `0.8.7` since `0.8.6` created a bad gem release

```
[= rclemente@mbp <~/Code/zendesk/abbreviato>  (master) =]
$> gem yank abbreviato -v 0.8.6 --host https://rubygems.org
Yanking gem from https://rubygems.org...
abbreviato 0.8.6 has already been deleted

[= rclemente@mbp <~/Code/zendesk/abbreviato>  (master) =]
$> bundle exec rake release
abbreviato 0.8.6 built to pkg/abbreviato-0.8.6.gem.
abbreviato 0.8.6 built to pkg/abbreviato-0.8.6.gem.
Tag v0.8.6 has already been created.
Tag v0.8.6 has already been created.
rake aborted!
Pushing gem to https://rubygems.org...
Repushing of gem versions is not allowed.
Please use `gem yank` to remove bad gem releases.
/Users/rclemente/.rbenv/versions/2.4.4/bin/bundle:23:in `load'
/Users/rclemente/.rbenv/versions/2.4.4/bin/bundle:23:in `<main>'
Tasks: TOP => release => release:rubygem_push
(See full trace by running task with --trace)
```


Fixes also the failing build
https://travis-ci.org/zendesk/abbreviato/jobs/495381236
```
Local version 0.64.0 of rubocop is not the latest version 0.65.0
```

cc @zendesk/sustaining 
