### PR TITLE
v0.8.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abbreviato (0.8.7)
+    abbreviato (0.8.8)
       htmlentities (~> 4.3.4)
       nokogiri (>= 1.8.5)
 

--- a/lib/abbreviato/version.rb
+++ b/lib/abbreviato/version.rb
@@ -1,3 +1,3 @@
 module Abbreviato
-  VERSION = '0.8.7'.freeze
+  VERSION = '0.8.8'.freeze
 end


### PR DESCRIPTION
### Description
there was bad release for `0.8.6` and `0.8.7` in rubygems so we neeed a new tag 

