### PR TITLE
Bump Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     abbreviato (0.8.9)
       htmlentities (~> 4.3.4)
-      nokogiri (>= 1.8.5)
+      nokogiri (>= 1.10.4)
 
 GEM
   remote: https://rubygems.org/
@@ -32,7 +32,7 @@ GEM
     jaro_winkler (1.5.3)
     memory_profiler (0.9.12)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)
@@ -92,4 +92,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/abbreviato.gemspec
+++ b/abbreviato.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.summary = "A tool for efficiently truncating HTML strings to a specific bytesize"
 
   s.add_dependency "htmlentities", "~> 4.3.4"
-  s.add_dependency "nokogiri", ">= 1.8.5"
+  s.add_dependency "nokogiri", ">= 1.10.4"
 
   s.add_development_dependency "awesome_print"
   s.add_development_dependency "benchmark-memory"


### PR DESCRIPTION
### Description
A new CVE has been released for Nokogiri versions less than 1.10.4.
https://nvd.nist.gov/vuln/detail/CVE-2019-5477

Although we are not using the affected methods, it's an easy enough gem
bump and will need to be done sooner or later anyway.