### PR TITLE
update nokigiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     abbreviato (0.9.3)
       htmlentities (~> 4.3.4)
-      nokogiri (>= 1.10.7)
+      nokogiri (>= 1.10.8)
 
 GEM
   remote: https://rubygems.org/
@@ -33,7 +33,7 @@ GEM
     jaro_winkler (1.5.4)
     memory_profiler (0.9.14)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.1)
     parser (2.7.0.3)

--- a/abbreviato.gemspec
+++ b/abbreviato.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.summary = "A tool for efficiently truncating HTML strings to a specific bytesize"
 
   s.add_dependency "htmlentities", "~> 4.3.4"
-  s.add_dependency "nokogiri", ">= 1.10.7"
+  s.add_dependency "nokogiri", ">= 1.10.8"
 
   s.add_development_dependency "awesome_print"
   s.add_development_dependency "benchmark-memory"


### PR DESCRIPTION
cc @zendesk/znoc 

### Description
```
moderate severity
Vulnerable versions: < 1.10.8
Patched version: 1.10.8
xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite loop in a certain end-of-file situation.
The Nokogiri RubyGem has patched it's vendored copy of libxml2 in order to prevent this issue from affecting nokogiri.
```


