### PR TITLE
[CVE-2024-41946] Bump rexml 3.3.5 (was 3.2.8)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,8 @@ GEM
     rainbow (3.0.0)
     rake (13.0.1)
     regexp_parser (2.1.1)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.5)
+      strscan
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -105,4 +105,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.4.12
+   2.5.5


### PR DESCRIPTION
### Description

Bump rexml 3.3.5 (was 3.2.8) to avoid CVE-2024-41946.

```
Name: rexml
Version: 3.2.8
CVE: CVE-2024-39908
GHSA: GHSA-4xqq-m2hx-25v8
Criticality: Medium
URL: https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8
Title: DoS in REXML
Solution: upgrade to '>= 3.3.2'

Name: rexml
Version: 3.2.8
CVE: CVE-2024-41123
GHSA: GHSA-r55c-59qm-vjw6
Criticality: Medium
URL: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123
Title: DoS vulnerabilities in REXML
Solution: upgrade to '>= 3.3.3'

Name: rexml
Version: 3.2.8
CVE: CVE-2024-41946
GHSA: GHSA-5866-49gr-[22](https://github.com/zendesk/abbreviato/actions/runs/10360400669/job/28678744397#step:5:23)v4
Criticality: Medium
URL: https://www.ruby-lang.org/en/news/20[24](https://github.com/zendesk/abbreviato/actions/runs/10360400669/job/28678744397#step:5:25)/08/01/dos-rexml-cve-2024-41946
Title: DoS vulnerabilities in REXML
Solution: upgrade to '>= 3.3.3'

Vulnerabilities found!
Error: Process completed with exit code 1.
```

### References

* CVE-2024-41946
* Run: https://github.com/zendesk/abbreviato/actions/runs/10360400669/job/28678744397