### PR TITLE
Missing release commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.0] - 2025-02-25
 
 * Drops support for Ruby 3.0
 * Bumps nokogiri to 1.18.3
 * Bumps rubocop to 1.73 to ensure we have support for ruby 3.3
 * Bumps ruby to 3.3.7
+
+## [3.1.4] - 2025-01-23
+
+* No/OP
+
+## [3.1.3] - 2025-01-23
+
+* No/OP
+
+## [3.1.2] - 2025-01-23
+
+* Set nokogiri gem to v1.17.2
+* Updates rexml from 3.2.8 to 3.3.3
+
+## [3.1.1] - 2024-08-13
+
+* Bump rexml from 3.2.8 to 3.3.3.
+
+## [3.1.0] - 2024-08-13
+
+* Bump the bundler group across 1 directory with 2 updates.
+
+## [3.0.0] - 2024-03-06
+
+* Drops support for Ruby 2.7
+* Adds tests on Ruby 3.3
 
 ## [2.0.0] - 2023-06-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ Pull requests are welcome on GitHub at https://github.com/zendesk/abbreviato
 After merging your changes into master, cut a tag and push it immediately:
 
 1. Update the version in `lib/abbreviato/version.rb`.
-2. Update the repository `git push --tags`
-3. Run `gem build abbreviato.gemspec`
-4. Run `gem push abbreviato-x.y.z.gem`
+1. Run `git tag -a vX.X.X -m "Describe the changes"` (replace with your tag).
+1. Update the repository `git push --tags`
+1. Run `gem build abbreviato.gemspec`
+1. Run `gem push abbreviato-x.y.z.gem`
 
 Note: you need proper credientials from http://rubygems.org. You can follow the guide at [api-authorization](https://guides.rubygems.org/rubygems-org-api/#api-authorization).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abbreviato (3.1.4)
+    abbreviato (3.2.0)
       htmlentities (~> 4.3.4)
       nokogiri (~> 1.18)
 

--- a/lib/abbreviato/version.rb
+++ b/lib/abbreviato/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Abbreviato
-  VERSION = '3.1.4'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
### Description

v3.2.0 and master were different commits. Let’s get the tag merged into master.

Diff: https://github.com/zendesk/abbreviato/compare/v3.2.0..6307a7621cb0865502d16671d862f2f8aac5cc3c