### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,7 @@
 name: Continuous Integration
 on: [push]
+permissions:
+  contents: read
 jobs:
   specs:
     name: specs
@@ -21,7 +23,6 @@ jobs:
         bundler-cache: true
     - name: Run specs on Ruby ${{ matrix.ruby }}
       run: bundle exec rake spec
-
   linter:
     name: linter
     runs-on: ubuntu-latest
@@ -31,7 +32,6 @@ jobs:
       with:
         bundler-cache: true
     - run: bundle exec rake lint
-
   specs_successful:
     name: Specs passing?
     needs: specs

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,5 +1,4 @@
 name: "CodeQL public repository scanning"
-
 on:
   push:
     branches:
@@ -9,13 +8,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
-
 permissions:
   contents: read
   security-events: write
   actions: read
   packages: read
-
 jobs:
   trigger-codeql:
     uses: zendesk/prodsec-code-scanning/.github/workflows/codeql_advanced_shared.yml@production

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
 name: Publish to RubyGems.org
-
 on:
   push:
     branches: main
     paths: lib/abbreviato/version.rb
   workflow_dispatch:
-
+permissions:
+  contents: read
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -20,7 +20,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: false
-          
       - name: Install dependencies
         run: bundle install
       - uses: rubygems/release-gem@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,7 @@
 name: Security
 on: [push]
+permissions:
+  contents: read
 jobs:
   main:
     name: bundle-audit


### PR DESCRIPTION
### Description

> If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.
> 
> #### Recommendation
> Add the permissions key to the job or the root of workflow (in this case it is applied to all jobs in the workflow that do not have their own permissions key) and assign the least privileges required to complete the task.

### References

* FIXES https://github.com/zendesk/abbreviato/security/code-scanning/1
* FIXES https://github.com/zendesk/abbreviato/security/code-scanning/2
* FIXES https://github.com/zendesk/abbreviato/security/code-scanning/3
* FIXES https://github.com/zendesk/abbreviato/security/code-scanning/4
* Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions