### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS file
+# This file defines who should review code changes in this repository.
+#
+# Team ownership is managed via Zendesk Identity Governance (ZIG):
+# https://github.com/zendesk/zendesk-identity-governance
+
+* @zendesk/strong-bad


### PR DESCRIPTION
This PR adds a CODEOWNERS file to ensure proper code review coverage.

According to Zendesk standards, all public repositories should have CODEOWNERS files:
- https://techmenu.zende.sk/standards/project-repository-contents/index.html

The CODEOWNERS file specifies who should review code changes in this repository.